### PR TITLE
[Android][Sample] Updated Indentity_Integration and Gameplay

### DIFF
--- a/MobileSDK/Integration/Identity_Integration.cpp
+++ b/MobileSDK/Integration/Identity_Integration.cpp
@@ -195,28 +195,5 @@ HRESULT Identity_GetGamerProfileAsync(_In_ XTaskQueueHandle asyncQueue, _In_ Xbl
 }
 
 // TODO: Add in GetGamerTag, GetGamerPic, and GetGamerScore when all functions are fully supported by XAL
-HRESULT Identity_GetGamerTag(_In_ XblUserHandle user, _Out_ std::string* gamertag)
-{
-    char gamertagBuffer[XBL_GAMERTAG_CHAR_SIZE];
-    size_t gamertagSize = 0;
 
-    HRESULT hr = XalUserGetGamertag(user, XBL_GAMERTAG_CHAR_SIZE, gamertagBuffer, &gamertagSize);
-
-    if (SUCCEEDED(hr))
-    {
-        if (gamertagSize > 0)
-        {
-            --gamertagSize; // To get rid of the '\0' at the end of the buffer
-        }
-
-        *gamertag = std::string(gamertagBuffer, gamertagSize);
-    }
-    else
-    {
-        SampleLog(LL_ERROR, "XalUserGetGamertag failed!");
-        SampleLog(LL_ERROR, "Error code: %s", ConvertHRtoString(hr).c_str());
-    }
-
-    return hr;
-}
 #pragma endregion

--- a/MobileSDK/Integration/Identity_Integration.h
+++ b/MobileSDK/Integration/Identity_Integration.h
@@ -11,7 +11,6 @@ HRESULT Identity_GetDefaultGamerProfileAsync(_In_ XTaskQueueHandle asyncQueue, _
 HRESULT Identity_GetGamerProfileAsync(_In_ XTaskQueueHandle asyncQueue, _In_ XblContextHandle contextHandle, _In_ uint64_t xboxUserId);
 
 // TODO: Add in GetGamerTag, GetGamerPic, and GetGamerScore when all functions are fully supported by XAL, for now call GetGamerProfileAsync
-HRESULT Identity_GetGamerTag(_In_ XblUserHandle user, _Out_ std::string* gamertag);
 
 // Identity_Gameplay functions
 void Identity_Gameplay_TrySignInUserSilently(_In_ XalUserHandle newUser, _In_ HRESULT result);


### PR DESCRIPTION
Got rid of Identity_GetGamerTag, since it was storing gamerTag twice (in both char* and std::string). Moved duplicated code out of Identity_Gameplay_WelcomeUser and Identity_Gameplay_GoodbyeUser into Identity_Gameplay_UserSignInOutMessage.